### PR TITLE
Change download button to use href attribute instead of JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             <div class="jumbotron">
                 <p style="font-weight:bold;" class="lead heading">micro</p>
                 <p class="lead">a modern and intuitive terminal-based text editor</p>
-                <p><a class="btn btn-lg btn-success" onclick="download_page()" role="button">Download</a></p>
+                <p><a class="btn btn-lg btn-success" href="https://github.com/zyedidia/micro/releases/latest" role="button">Download</a></p>
                 <a class="github-button" href="https://github.com/zyedidia/micro" data-size="large" data-show-count="true" aria-label="Star zyedidia/micro on GitHub">Star</a>
                 <p><a style='font-size: 16px;' href="https://github.com/zyedidia/micro#installation">See detailed installation instructions</a></p>
             </div>
@@ -188,12 +188,5 @@
 
         <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
         <script src="micro_files/ie10-viewport-bug-workaround.js"></script>
-
-        <script>
-            function download_page() {
-                var win = window.open("https://github.com/zyedidia/micro/releases/latest", '_blank');
-                win.focus();
-            }
-        </script>
     </body>
 </html>


### PR DESCRIPTION
There's no reason to be using JS here if all it does is open a new window.

I have changed the behaviour slightly here, as it will no longer open in a new window. See [When to use target="_blank"](https://css-tricks.com/use-target_blank/) for some good reasons not to open things in new windows.

Fixes https://github.com/zyedidia/micro/issues/1198