### PR TITLE
Improve website (semantics)

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,108 +32,107 @@
         </script>
     </head>
     <body>
-
-        <div class="container">
-            <header class="clearfix">
-                <div class="navbar-header pull-left">
-                    <a href="index.html" class="micro-logo">Micro</a>
-                </div>
-
-                <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
-
-                <nav class="collapse navbar-collapse navbar-right">
-                    <ul class="nav navbar-nav pull-right">
-                        <li><a href="index.html">home</a></li>
-                        <li class="active"><a href="about.html">about</a></li>
-                        <li><a href="plugins.html">plugins</a></li>
-                        <li><a href="https://github.com/zyedidia/micro">development</a></li>
-                    </ul>
-                </nav>
-            </header>
-
-            <div class="row about">
-                <div class="col-lg-12">
-                    <div class="heading">
-                        <h2>About</h2>
-                    </div>
-                    <p>Micro is a terminal-based text editor that aims to be easy to use and intuitive, while also taking advantage of the full capabilities of modern terminals. It comes as one single, batteries-included, static binary with no dependencies, and you can download and use it right now.</p>
-
-                    <p>As the name indicates, micro aims to be somewhat of a successor to the nano editor by being easy to install and use in a pinch, but micro also aims to be enjoyable to use full time, whether you work in the terminal because you prefer it (like me), or because you need to (over ssh).</p>
-                </div>
+        <header class="clearfix">
+            <div class="navbar-header pull-left">
+                <a href="index.html" class="micro-logo">Micro</a>
             </div>
 
-            <hr>
+            <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
 
-            <div class="row docs">
-                <div class="col-lg-12">
-                    <div class="heading">
-                        <h2>Documentation and Help</h2>
-                    </div>
-                </div>
-                <div class="col-sm-8">
-                    <p>Micro has a built-in help system which you can access by pressing <code>Ctrl-E</code> and typing <code>help topic</code>. You can also press <code>Ctrl-G</code> to open the main help file. The help files are also viewable online in the GitHub repository.</p>
-                    <p>I also recommend reading the <a href="https://github.com/zyedidia/micro/tree/master/runtime/help/tutorial.md">tutorial</a> for
-                        a brief introduction to the more powerful configuration features micro offers.</p>
+            <nav class="collapse navbar-collapse navbar-right">
+                <ul class="nav navbar-nav pull-right">
+                    <li><a href="index.html">home</a></li>
+                    <li class="active"><a href="about.html">about</a></li>
+                    <li><a href="plugins.html">plugins</a></li>
+                    <li><a href="https://github.com/zyedidia/micro">development</a></li>
+                </ul>
+            </nav>
+        </header>
 
-                    <br>
-                    <p>If you have any questions, feel free to open an issue in the <a href="https://github.com/zyedidia/micro/issues">GitHub issue tracker</a> or to ask more informally in the <a href="https://gitter.im/zyedidia/micro">Gitter chat</a></p>
+        <main>
+        <div class="row about">
+            <div class="col-lg-12">
+                <div class="heading">
+                    <h2>About</h2>
                 </div>
-                <div class="col-sm-1">
-                </div>
-                <div class="col-sm-3">
-                    <h4>Help topics</h4>
-                    <ul style="list-style-type:none; padding:0;">
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/help.md">main help</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/keybindings.md">keybindings</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/commands.md">commands</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/colors.md">colors</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/options.md">options</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/plugins.md">plugins</a></li>
-                    </ul>
+                <p>Micro is a terminal-based text editor that aims to be easy to use and intuitive, while also taking advantage of the full capabilities of modern terminals. It comes as one single, batteries-included, static binary with no dependencies, and you can download and use it right now.</p>
+
+                <p>As the name indicates, micro aims to be somewhat of a successor to the nano editor by being easy to install and use in a pinch, but micro also aims to be enjoyable to use full time, whether you work in the terminal because you prefer it (like me), or because you need to (over ssh).</p>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="row docs">
+            <div class="col-lg-12">
+                <div class="heading">
+                    <h2>Documentation and Help</h2>
                 </div>
             </div>
+            <div class="col-sm-8">
+                <p>Micro has a built-in help system which you can access by pressing <code>Ctrl-E</code> and typing <code>help topic</code>. You can also press <code>Ctrl-G</code> to open the main help file. The help files are also viewable online in the GitHub repository.</p>
+                <p>I also recommend reading the <a href="https://github.com/zyedidia/micro/tree/master/runtime/help/tutorial.md">tutorial</a> for
+                    a brief introduction to the more powerful configuration features micro offers.</p>
 
-            <hr>
-
-            <div class="row faq">
-                <div class="col-lg-12">
-                    <div class="heading">
-                        <h2>FAQs</h2>
-                    </div>
-                    <h4>Does micro support Vi keybindings?</h4>
-                    <p>Currently micro does not have any sort of Vim emulation. However, this is the next major feature that is planned, so stay tuned.</p>
-                    <br>
-                    <h4>Can micro support the Command key on MacOS?</h4>
-                    <p>Unfortunately terminals don't send key events for the Command key so it's impossible for micro to make keybindings for it. One solution in iTerm2 is in 'Preferences-&gt;Keys-&gt;Remap Modifiers' and select 'Remap left command key to control.' Note that command will no longer be usable in iTerm2 for terminal keybindings (such as command-q to quit, or command-d to split).</p>
-                    <br>
-                    <h4>Can I contribute even if I don't know Go?</h4>
-                    <p>Yes! You can help by creating colorschemes or syntax files or by improving the documentation. If you know Lua you can write plugins.</p>
-                    <br>
-                    <h4>Syntax highlighting isn't working well. I only see a few colors/no colors</h4>
-                    <p>Your <code>TERM</code> variable probably indicates that your terminal only supports 16 colors. You can change it like so to enable 256 colors: <code>$ export TERM=xterm-256color</code>. Alternatively you can use one of micro's 16 color colorschemes by running <code>> set colorscheme simple</code>.
-                    </div>
-                </div>
-
-                <hr>
-
-                <div class="row logos">
-                    <div class="col-lg-12">
-                        <div class="heading">
-                            <h2>Logos</h2>
-                        </div>
-                        <p>You can download both SVG and PNG versions of the Micro logo for free in the following zip file.</p>
-
-                        <a href="micro-logos.zip">micro-logos.zip</a>
-                    </div>
-                </div>
                 <br>
+                <p>If you have any questions, feel free to open an issue in the <a href="https://github.com/zyedidia/micro/issues">GitHub issue tracker</a> or to ask more informally in the <a href="https://gitter.im/zyedidia/micro">Gitter chat</a></p>
+            </div>
+            <div class="col-sm-1">
+            </div>
+            <div class="col-sm-3">
+                <h4>Help topics</h4>
+                <ul style="list-style-type:none; padding:0;">
+                    <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/help.md">main help</a></li>
+                    <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/keybindings.md">keybindings</a></li>
+                    <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/commands.md">commands</a></li>
+                    <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/colors.md">colors</a></li>
+                    <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/options.md">options</a></li>
+                    <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/plugins.md">plugins</a></li>
+                </ul>
+            </div>
+        </div>
 
-                <footer>
-                    <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
-                </footer>
-            </div> <!-- /container -->
+        <hr>
 
-            <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-            <script src="micro_files/ie10-viewport-bug-workaround.js"></script>
-        </body>
-    </html>
+        <div class="row faq">
+            <div class="col-lg-12">
+                <div class="heading">
+                    <h2>FAQs</h2>
+                </div>
+                <h4>Does micro support Vi keybindings?</h4>
+                <p>Currently micro does not have any sort of Vim emulation. However, this is the next major feature that is planned, so stay tuned.</p>
+                <br>
+                <h4>Can micro support the Command key on MacOS?</h4>
+                <p>Unfortunately terminals don't send key events for the Command key so it's impossible for micro to make keybindings for it. One solution in iTerm2 is in 'Preferences-&gt;Keys-&gt;Remap Modifiers' and select 'Remap left command key to control.' Note that command will no longer be usable in iTerm2 for terminal keybindings (such as command-q to quit, or command-d to split).</p>
+                <br>
+                <h4>Can I contribute even if I don't know Go?</h4>
+                <p>Yes! You can help by creating colorschemes or syntax files or by improving the documentation. If you know Lua you can write plugins.</p>
+                <br>
+                <h4>Syntax highlighting isn't working well. I only see a few colors/no colors</h4>
+                <p>Your <code>TERM</code> variable probably indicates that your terminal only supports 16 colors. You can change it like so to enable 256 colors: <code>$ export TERM=xterm-256color</code>. Alternatively you can use one of micro's 16 color colorschemes by running <code>> set colorscheme simple</code>.
+                </div>
+            </div>
+
+            <hr>
+
+            <div class="row logos">
+                <div class="col-lg-12">
+                    <div class="heading">
+                        <h2>Logos</h2>
+                    </div>
+                    <p>You can download both SVG and PNG versions of the Micro logo for free in the following zip file.</p>
+
+                    <a href="micro-logos.zip">micro-logos.zip</a>
+                </div>
+            </div>
+        </main>
+
+        <br>
+
+        <footer>
+            <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
+        </footer>
+        <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+        <script src="micro_files/ie10-viewport-bug-workaround.js"></script>
+    </body>
+</html>

--- a/about.html
+++ b/about.html
@@ -34,22 +34,22 @@
     <body>
 
         <div class="container">
-            <div class="header clearfix">
+            <header class="clearfix">
                 <div class="navbar-header pull-left">
                     <a href="index.html" class="micro-logo">Micro</a>
                 </div>
 
                 <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
 
-                <div class="collapse navbar-collapse navbar-right">
+                <nav class="collapse navbar-collapse navbar-right">
                     <ul class="nav navbar-nav pull-right">
                         <li><a href="index.html">home</a></li>
                         <li class="active"><a href="about.html">about</a></li>
                         <li><a href="plugins.html">plugins</a></li>
                         <li><a href="https://github.com/zyedidia/micro">development</a></li>
                     </ul>
-                </div>
-            </div>
+                </nav>
+            </header>
 
             <div class="row about">
                 <div class="col-lg-12">
@@ -128,7 +128,7 @@
                 </div>
                 <br>
 
-                <footer class="footer">
+                <footer>
                     <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
                 </footer>
             </div> <!-- /container -->

--- a/index.html
+++ b/index.html
@@ -45,190 +45,188 @@
     </head>
 
     <body>
-
-        <div class="container">
-            <header class="clearfix">
-                <div class="navbar-header pull-left">
-                    <a href="index.html" class="micro-logo">Micro</a>
-                </div>
-
-                <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
-
-                <nav class="collapse navbar-collapse navbar-right">
-                    <ul class="nav navbar-nav pull-right">
-                        <li class="active"><a href="index.html">home</a></li>
-                        <li><a href="about.html">about</a></li>
-                        <li><a href="plugins.html">plugins</a></li>
-                        <li><a href="https://github.com/zyedidia/micro">development</a></li>
-                    </ul>
-                </nav>
-            </header>
-
-            <div class="jumbotron">
-                <p style="font-weight:bold;" class="lead heading">micro</p>
-                <p class="lead">a modern and intuitive terminal-based text editor</p>
-                <p><a class="btn btn-lg btn-success" href="https://github.com/zyedidia/micro/releases/latest" role="button">Download</a></p>
-                <pre style="max-width:20em;clear:both;text-align:center;margin:0 auto"><code id="selectable" onclick="selectText(this)">curl https://getmic.ro | bash</code></pre><br>
-                <a class="github-button" href="https://github.com/zyedidia/micro" data-size="large" data-show-count="true" aria-label="Star zyedidia/micro on GitHub">Star</a>
-                <p><a style='font-size: 16px;' href="https://github.com/zyedidia/micro#installation">See detailed installation instructions</a></p>
-            </div>
-            <hr>
-
-            <div id="screenshots" class="carousel slide" data-ride="carousel">
-                <!-- Indicators -->
-                <ol class="carousel-indicators">
-                    <li data-target="#screenshots" data-slide-to="0" class="active"></li>
-                    <li data-target="#screenshots" data-slide-to="1"></li>
-                    <li data-target="#screenshots" data-slide-to="2"></li>
-                    <li data-target="#screenshots" data-slide-to="3"></li>
-                    <li data-target="#screenshots" data-slide-to="4"></li>
-                    <li data-target="#screenshots" data-slide-to="5"></li>
-                    <li data-target="#screenshots" data-slide-to="6"></li>
-                    <li data-target="#screenshots" data-slide-to="7"></li>
-                    <li data-target="#screenshots" data-slide-to="8"></li>
-                    <li data-target="#screenshots" data-slide-to="9"></li>
-                    <li data-target="#screenshots" data-slide-to="10"></li>
-                </ol>
-
-                <!-- Wrapper for slides -->
-                <div class="carousel-inner" role="listbox">
-                    <div class="item active">
-                        <img src="screenshots/micro-monokai.png" alt="Chania">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-one-dark.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-darcula.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-twilight.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-railscast.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-solarized.png" alt="Chania">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-atom-dark.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-gruvbox.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-material.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-gotham.png" alt="Flower">
-                    </div>
-
-                    <div class="item">
-                        <img src="screenshots/micro-zenburn.png" alt="Flower">
-                    </div>
-                </div>
-
-                <!-- Left and right controls -->
-                <a class="left carousel-control" href="#screenshots" role="button" data-slide="prev">
-                    <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                    <span class="sr-only">Previous</span>
-                </a>
-                <a class="right carousel-control" href="#screenshots" role="button" data-slide="next">
-                    <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                    <span class="sr-only">Next</span>
-                </a>
+        <header class="clearfix">
+            <div class="navbar-header pull-left">
+                <a href="index.html" class="micro-logo">Micro</a>
             </div>
 
-            <hr>
+            <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
 
-            <div class="row features">
-                <div class="heading">
-                    <div class="col-lg-12">
-                        <h2>Features</h2>
-                    </div>
+            <nav class="collapse navbar-collapse navbar-right">
+                <ul class="nav navbar-nav pull-right">
+                    <li class="active"><a href="index.html">home</a></li>
+                    <li><a href="about.html">about</a></li>
+                    <li><a href="plugins.html">plugins</a></li>
+                    <li><a href="https://github.com/zyedidia/micro">development</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main>
+        <div class="jumbotron">
+            <p style="font-weight:bold;" class="lead heading">micro</p>
+            <p class="lead">a modern and intuitive terminal-based text editor</p>
+            <p><a class="btn btn-lg btn-success" href="https://github.com/zyedidia/micro/releases/latest" role="button">Download</a></p>
+            <pre style="max-width:20em;clear:both;text-align:center;margin:0 auto"><code id="selectable" onclick="selectText(this)">curl https://getmic.ro | bash</code></pre><br>
+            <a class="github-button" href="https://github.com/zyedidia/micro" data-size="large" data-show-count="true" aria-label="Star zyedidia/micro on GitHub">Star</a>
+            <p><a style='font-size: 16px;' href="https://github.com/zyedidia/micro#installation">See detailed installation instructions</a></p>
+        </div>
+        <hr>
+
+        <div id="screenshots" class="carousel slide" data-ride="carousel">
+            <!-- Indicators -->
+            <ol class="carousel-indicators">
+                <li data-target="#screenshots" data-slide-to="0" class="active"></li>
+                <li data-target="#screenshots" data-slide-to="1"></li>
+                <li data-target="#screenshots" data-slide-to="2"></li>
+                <li data-target="#screenshots" data-slide-to="3"></li>
+                <li data-target="#screenshots" data-slide-to="4"></li>
+                <li data-target="#screenshots" data-slide-to="5"></li>
+                <li data-target="#screenshots" data-slide-to="6"></li>
+                <li data-target="#screenshots" data-slide-to="7"></li>
+                <li data-target="#screenshots" data-slide-to="8"></li>
+                <li data-target="#screenshots" data-slide-to="9"></li>
+                <li data-target="#screenshots" data-slide-to="10"></li>
+            </ol>
+
+            <!-- Wrapper for slides -->
+            <div class="carousel-inner" role="listbox">
+                <div class="item active">
+                    <img src="screenshots/micro-monokai.png" alt="Chania">
                 </div>
-                <div class="col-sm-6">
-                    <h4>Easy to Use</h4>
-                    <p>Micro's number one feature is being easy to install (it's just a static binary with no dependencies) and easy to use.</p>
 
-                    <h4>Highly Customizable</h4>
-                    <p>Use a simple json format to configure your options and rebind keys to your liking. If you need more power, you can use Lua to configure the editor further.</p>
-
-                    <h4>Colors and Highlighting</h4>
-                    <p>Micro supports over 75 languages and has 7 default colorschemes to choose from. Micro supports 16, 256, and truecolor themes. Syntax files and colorschemes are also very simple to make.</p>
-
-                    <h4>Multiple Cursors</h4>
-                    <p>Micro has support for Sublime-style multiple cursors, giving you lots of editing power directly in your terminal.</p>
+                <div class="item">
+                    <img src="screenshots/micro-one-dark.png" alt="Flower">
                 </div>
 
-                <div class="col-sm-6">
-                    <h4>Plugin System</h4>
-                    <p>Micro supports a full-blown plugin system. Plugins are written in Lua and there is a plugin manager to automatically download and install your plugins for you.</p>
-
-                    <h4>Common Keybindings</h4>
-                    <p>Micro's keybindings are what you would expect from a simple-to-use editor. You can also rebind any of the bindings without problem in the <code>bindings.json</code> file.</p>
-
-                    <h4>Mouse Support</h4>
-                    <p>Micro has full support for the mouse. This means you can click and drag to select text, double click select by word, and triple click to select by line.</p>
-
-                    <h4>Terminal Emulator</h4>
-                    <p>Run a real interactive shell from within micro. You could open up a split with code on one side and bash on the other -- all from within micro.</p>
+                <div class="item">
+                    <img src="screenshots/micro-darcula.png" alt="Flower">
                 </div>
 
+                <div class="item">
+                    <img src="screenshots/micro-twilight.png" alt="Flower">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-railscast.png" alt="Flower">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-solarized.png" alt="Chania">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-atom-dark.png" alt="Flower">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-gruvbox.png" alt="Flower">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-material.png" alt="Flower">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-gotham.png" alt="Flower">
+                </div>
+
+                <div class="item">
+                    <img src="screenshots/micro-zenburn.png" alt="Flower">
+                </div>
+            </div>
+
+            <!-- Left and right controls -->
+            <a class="left carousel-control" href="#screenshots" role="button" data-slide="prev">
+                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                <span class="sr-only">Previous</span>
+            </a>
+            <a class="right carousel-control" href="#screenshots" role="button" data-slide="next">
+                <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+                <span class="sr-only">Next</span>
+            </a>
+        </div>
+
+        <hr>
+
+        <div class="row features">
+            <div class="heading">
                 <div class="col-lg-12">
-                    <br>
-                    <p style="padding-top: 20px;">And much more! Check out the full list of features <a href="https://github.com/zyedidia/micro#features">here</a> as well as the built-in help system also viewable online <a href="https://github.com/zyedidia/micro/tree/master/runtime/help">here</a>.</p>
+                    <h2>Features</h2>
                 </div>
             </div>
+            <div class="col-sm-6">
+                <h4>Easy to Use</h4>
+                <p>Micro's number one feature is being easy to install (it's just a static binary with no dependencies) and easy to use.</p>
 
-            <hr>
+                <h4>Highly Customizable</h4>
+                <p>Use a simple json format to configure your options and rebind keys to your liking. If you need more power, you can use Lua to configure the editor further.</p>
 
-            <div class="row contributing">
-                <div class="col-md-6">
-                    <div class="heading">
-                        <h2>Contributing</h2>
-                    </div>
-                    <p>If you find any bugs, please report them! I am also happy to accept pull requests from anyone.</p>
-                    <p>You can use the GitHub issue tracker to report bugs, ask questions, or suggest new features.</p>
-                    <p>For a more informal setting to discuss the editor, you can join the Gitter chat.</p>
-                    <br>
-                    <div class="col-sm-6">
-                        <p style="text-align:center"><a class="btn btn-md btn-success" href="https://github.com/zyedidia/micro" role="button">View the GitHub project</a></p>
-                    </div>
-                    <div class="col-sm-6">
-                        <p style="text-align:center"><a class="btn btn-md btn-success" href="https://gitter.im/zyedidia/micro" role="button">Join the Gitter Chat</a></p>
-                    </div>
-                </div>
-                <div class="col-md-6">
-                    <div class="heading">
-                        <h2>Testimonials</h2>
-                    </div>
-                    <ul class="testimonials">
-                        <li><p><a href="https://gitter.im/zyedidia/micro?at=57c5b2069bac566763729ac2">"Finally a simple editor that just works, with amazing mouse support."</a></p></li>
-                        <li><p><a href="https://www.reddit.com/r/golang/comments/4f8e0q/micro_a_modern_and_intuitive_terminalbased_text/d26qse8">"I really love this. This is definitely replacing nano for me."</a></p></li>
-                        <li><p><a href="https://github.com/zyedidia/micro/issues/217#issuecomment-243134046">"Keep up the great work, you have saved me from Nano and Vim suffering!"</a></p></li>
-                        <li><p><a href="https://twitter.com/kelseyhightower/status/770735086400577536">"The micro text editor is dope."</a></p></li>
-                        <li><p><a href="https://www.reddit.com/r/commandline/comments/5059qw/micro_a_modern_and_intuitive_terminalbased_text/d71t2y8">"Nice, readable source, with generous use of comments. I wonder if this is that 'idiomatic go' I keep hearing about."</a></p></li>
-                    </ul>
-                </div>
+                <h4>Colors and Highlighting</h4>
+                <p>Micro supports over 75 languages and has 7 default colorschemes to choose from. Micro supports 16, 256, and truecolor themes. Syntax files and colorschemes are also very simple to make.</p>
+
+                <h4>Multiple Cursors</h4>
+                <p>Micro has support for Sublime-style multiple cursors, giving you lots of editing power directly in your terminal.</p>
             </div>
 
-            <br>
+            <div class="col-sm-6">
+                <h4>Plugin System</h4>
+                <p>Micro supports a full-blown plugin system. Plugins are written in Lua and there is a plugin manager to automatically download and install your plugins for you.</p>
 
-            <footer>
-                <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
-            </footer>
-        </div> <!-- /container -->
+                <h4>Common Keybindings</h4>
+                <p>Micro's keybindings are what you would expect from a simple-to-use editor. You can also rebind any of the bindings without problem in the <code>bindings.json</code> file.</p>
 
+                <h4>Mouse Support</h4>
+                <p>Micro has full support for the mouse. This means you can click and drag to select text, double click select by word, and triple click to select by line.</p>
+
+                <h4>Terminal Emulator</h4>
+                <p>Run a real interactive shell from within micro. You could open up a split with code on one side and bash on the other -- all from within micro.</p>
+            </div>
+
+            <div class="col-lg-12">
+                <br>
+                <p style="padding-top: 20px;">And much more! Check out the full list of features <a href="https://github.com/zyedidia/micro#features">here</a> as well as the built-in help system also viewable online <a href="https://github.com/zyedidia/micro/tree/master/runtime/help">here</a>.</p>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="row contributing">
+            <div class="col-md-6">
+                <div class="heading">
+                    <h2>Contributing</h2>
+                </div>
+                <p>If you find any bugs, please report them! I am also happy to accept pull requests from anyone.</p>
+                <p>You can use the GitHub issue tracker to report bugs, ask questions, or suggest new features.</p>
+                <p>For a more informal setting to discuss the editor, you can join the Gitter chat.</p>
+                <br>
+                <div class="col-sm-6">
+                    <p style="text-align:center"><a class="btn btn-md btn-success" href="https://github.com/zyedidia/micro" role="button">View the GitHub project</a></p>
+                </div>
+                <div class="col-sm-6">
+                    <p style="text-align:center"><a class="btn btn-md btn-success" href="https://gitter.im/zyedidia/micro" role="button">Join the Gitter Chat</a></p>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="heading">
+                    <h2>Testimonials</h2>
+                </div>
+                <ul class="testimonials">
+                    <li><p><a href="https://gitter.im/zyedidia/micro?at=57c5b2069bac566763729ac2">"Finally a simple editor that just works, with amazing mouse support."</a></p></li>
+                    <li><p><a href="https://www.reddit.com/r/golang/comments/4f8e0q/micro_a_modern_and_intuitive_terminalbased_text/d26qse8">"I really love this. This is definitely replacing nano for me."</a></p></li>
+                    <li><p><a href="https://github.com/zyedidia/micro/issues/217#issuecomment-243134046">"Keep up the great work, you have saved me from Nano and Vim suffering!"</a></p></li>
+                    <li><p><a href="https://twitter.com/kelseyhightower/status/770735086400577536">"The micro text editor is dope."</a></p></li>
+                    <li><p><a href="https://www.reddit.com/r/commandline/comments/5059qw/micro_a_modern_and_intuitive_terminalbased_text/d71t2y8">"Nice, readable source, with generous use of comments. I wonder if this is that 'idiomatic go' I keep hearing about."</a></p></li>
+                </ul>
+            </div>
+        </div>
+        </main>
+
+        <br>
+
+        <footer>
+            <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
+        </footer>
         <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
         <script src="micro_files/ie10-viewport-bug-workaround.js"></script>
     </body>

--- a/index.html
+++ b/index.html
@@ -47,22 +47,22 @@
     <body>
 
         <div class="container">
-            <div class="header clearfix">
+            <header class="clearfix">
                 <div class="navbar-header pull-left">
                     <a href="index.html" class="micro-logo">Micro</a>
                 </div>
 
                 <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
 
-                <div class="collapse navbar-collapse navbar-right">
+                <nav class="collapse navbar-collapse navbar-right">
                     <ul class="nav navbar-nav pull-right">
                         <li class="active"><a href="index.html">home</a></li>
                         <li><a href="about.html">about</a></li>
                         <li><a href="plugins.html">plugins</a></li>
                         <li><a href="https://github.com/zyedidia/micro">development</a></li>
                     </ul>
-                </div>
-            </div>
+                </nav>
+            </header>
 
             <div class="jumbotron">
                 <p style="font-weight:bold;" class="lead heading">micro</p>
@@ -224,7 +224,7 @@
 
             <br>
 
-            <footer class="footer">
+            <footer>
                 <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
             </footer>
         </div> <!-- /container -->

--- a/micro_files/micro.css
+++ b/micro_files/micro.css
@@ -77,6 +77,13 @@ header, main, footer {
     margin: 10px 0;
 }
 
+/* Fix scrollbars moving over the body if possible */
+@media (min-width: 800px) {
+  :root {
+    scrollbar-gutter: stable both-edges;
+  }
+}
+
 /* Main features message and sign up button */
 .jumbotron {
     text-align: center;

--- a/micro_files/micro.css
+++ b/micro_files/micro.css
@@ -60,11 +60,19 @@ footer {
 }
 
 /* Customize container */
+header, main, footer {
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+}
+
 @media (min-width: 768px) {
-    .container {
+    header, main, footer {
         max-width: 1100px;
     }
 }
+
 .container-narrow > hr {
     margin: 10px 0;
 }

--- a/micro_files/micro.css
+++ b/micro_files/micro.css
@@ -34,26 +34,26 @@ input[type="radio"] {
 }
 
 /* Everything but the jumbotron gets side spacing for mobile first views */
-.header,
-.footer {
+header,
+footer {
     padding-right: 15px;
     padding-left: 15px;
 }
 
 /* Custom page header */
-.header {
+header {
     padding-bottom: 20px;
     border-bottom: 1px solid #e5e5e5;
 }
 /* Make the masthead heading the same height as the navigation */
-.header h3 {
+header h3 {
     margin-top: 0;
     margin-bottom: 0;
     line-height: 40px;
 }
 
 /* Custom page footer */
-.footer {
+footer {
     padding-top: 19px;
     color: #777;
     border-top: 1px solid #e5e5e5;
@@ -122,11 +122,11 @@ p.lead {
     border-radius: 1px;
 }
 
-.nav > li > a, .nav-pills > li > a:hover, .nav-pills > li > a:hover {
+nav ul.nav > li > a, .nav-pills > li > a:hover, .nav-pills > li > a:hover {
     border-radius: 5px;
 }
 
-.nav > li.active > a, .nav-pills > li.active > a:focus, .nav-pills > li.active > a:hover {
+nav ul.nav > li.active > a, .nav-pills > li.active > a:focus, .nav-pills > li.active > a:hover {
     background-color: #2F3590;
     color: #fff;
     border-radius: 5px;

--- a/micro_files/micro.css
+++ b/micro_files/micro.css
@@ -122,6 +122,11 @@ p.lead {
     border-radius: 1px;
 }
 
+nav ul {
+    display: flex;
+    gap: 1ch;
+}
+
 nav ul.nav > li > a, .nav-pills > li > a:hover, .nav-pills > li > a:hover {
     border-radius: 5px;
 }

--- a/plugins.html
+++ b/plugins.html
@@ -32,24 +32,24 @@
         </script>
     </head>
     <body onload="fetchData()">
-        <div class="container">
-            <header class="clearfix">
-                <div class="navbar-header pull-left">
-                    <a href="index.html" class="micro-logo">Micro</a>
-                </div>
+        <header class="clearfix">
+            <div class="navbar-header pull-left">
+                <a href="index.html" class="micro-logo">Micro</a>
+            </div>
 
-                <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
+            <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
 
-                <nav class="collapse navbar-collapse navbar-right">
-                    <ul class="nav navbar-nav pull-right">
-                        <li><a href="index.html">home</a></li>
-                        <li><a href="about.html">about</a></li>
-                        <li class="active"><a href="plugins.html">plugins</a></li>
-                        <li><a href="https://github.com/zyedidia/micro">development</a></li>
-                    </ul>
-                </nav>
-            </header>
+            <nav class="collapse navbar-collapse navbar-right">
+                <ul class="nav navbar-nav pull-right">
+                    <li><a href="index.html">home</a></li>
+                    <li><a href="about.html">about</a></li>
+                    <li class="active"><a href="plugins.html">plugins</a></li>
+                    <li><a href="https://github.com/zyedidia/micro">development</a></li>
+                </ul>
+            </nav>
+        </header>
 
+        <main>
             <div class="row about">
                 <div class="col-lg-12">
                     <div class="heading">
@@ -57,16 +57,16 @@
                     </div>
                     <div>
                         <input type="radio" name="searchby" value="Name"
-                          checked="true">Name</option>
+                            checked="true">Name</option>
                         <input type="radio" name="searchby" value="Description">Description</option>
                         <input type="radio" name="searchby" value="Tags">Tags</option>
                         <br/><br/>
-                      <div class="input-group">
+                        <div class="input-group">
                         <input type="text" class="form-control" placeholder="Search plugins..." onchange="search(false)" id="keyword">
                         <span class="input-group-btn">
-                          <button id="searchbutton" class="btn btn-success" type="button" onclick="search(false)">Search</button>
+                            <button id="searchbutton" class="btn btn-success" type="button" onclick="search(false)">Search</button>
                         </span>
-                      </div><!-- /input-group -->
+                        </div><!-- /input-group -->
                     </div>
                     <hr />
                     <div class="panel-group" id="results" role="tablist" aria-multiselectable="true">
@@ -74,16 +74,14 @@
                     </div>
                 </div>
             </div>
+        </main>
 
-
-                <footer>
-                    <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
-                </footer>
-            </div> <!-- /container -->
-
-            <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-            <script src="micro_files/ie10-viewport-bug-workaround.js"></script>
-            <script src="micro_files/fetch.js"></script>
-            <script src="micro_files/plugin-search.js"></script>
-        </body>
-    </html>
+        <footer>
+            <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
+        </footer>
+        <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+        <script src="micro_files/ie10-viewport-bug-workaround.js"></script>
+        <script src="micro_files/fetch.js"></script>
+        <script src="micro_files/plugin-search.js"></script>
+    </body>
+</html>

--- a/plugins.html
+++ b/plugins.html
@@ -33,22 +33,22 @@
     </head>
     <body onload="fetchData()">
         <div class="container">
-            <div class="header clearfix">
+            <header class="clearfix">
                 <div class="navbar-header pull-left">
                     <a href="index.html" class="micro-logo">Micro</a>
                 </div>
 
                 <button type="button" data-toggle="collapse" data-target=".navbar-collapse" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
 
-                <div class="collapse navbar-collapse navbar-right">
+                <nav class="collapse navbar-collapse navbar-right">
                     <ul class="nav navbar-nav pull-right">
                         <li><a href="index.html">home</a></li>
                         <li><a href="about.html">about</a></li>
                         <li class="active"><a href="plugins.html">plugins</a></li>
                         <li><a href="https://github.com/zyedidia/micro">development</a></li>
                     </ul>
-                </div>
-            </div>
+                </nav>
+            </header>
 
             <div class="row about">
                 <div class="col-lg-12">
@@ -76,7 +76,7 @@
             </div>
 
 
-                <footer class="footer">
+                <footer>
                     <p>View the source code for this website on <a href="https://github.com/micro-editor/micro-editor.github.io">GitHub</a></p>
                 </footer>
             </div> <!-- /container -->


### PR DESCRIPTION
Makes the website more semantic and adds a slight space on the header buttons.

Since the semantics are literally just the semantics, you can't see them. The header is slightly different and (in my opinion) slightly more aesthetically pleasing. If you disagree, I have left it as a separate commit for manual reverting.

## Before

No header gap (and stacked sideways borders because bootstrap moments)

![image](https://github.com/micro-editor/micro-editor.github.io/assets/109556932/5ce4af78-5145-4d52-adbc-4567a05d0c52)

## After

1ch header gap

![image](https://github.com/micro-editor/micro-editor.github.io/assets/109556932/98d6b1b7-b150-4d88-b539-a506bfd8cde2)

## Additional Info

In my opinion, if you're making multiple pages with lots of repeated stuff, you would be better off using a Static Site Generator like Hugo (if you already like it), Zola (less complex, I've seen it used for stuff like this), or Astro (more complex, likely not what you need) to make repeating stuff easier. If you switch to a tool like that, you may either want to use a GitHub action or manually build and serve the GitHub Pages from `dist/`.

I found some inconsistencies in the copied parts like the indented closing tags of the HTML and body for the about page. For those, you should also consider a formatter (I like Prettier).