### PR TITLE
Change `zyedidia/micro` to `micro-editor/micro`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micro Editor Website
 
-This is the website for the [micro text editor](https://github.com/zyedidia/micro).
+This is the website for the [micro text editor](https://github.com/micro-editor/micro).
 
 You can view it at https://micro-editor.github.io
 

--- a/about.html
+++ b/about.html
@@ -46,7 +46,7 @@
                         <li><a href="index.html">home</a></li>
                         <li class="active"><a href="about.html">about</a></li>
                         <li><a href="plugins.html">plugins</a></li>
-                        <li><a href="https://github.com/zyedidia/micro">development</a></li>
+                        <li><a href="https://github.com/micro-editor/micro">development</a></li>
                     </ul>
                 </div>
             </div>
@@ -72,23 +72,23 @@
                 </div>
                 <div class="col-sm-8">
                     <p>Micro has a built-in help system which you can access by pressing <code>Ctrl-E</code> and typing <code>help topic</code>. You can also press <code>Ctrl-G</code> to open the main help file. The help files are also viewable online in the GitHub repository.</p>
-                    <p>I also recommend reading the <a href="https://github.com/zyedidia/micro/tree/master/runtime/help/tutorial.md">tutorial</a> for
+                    <p>I also recommend reading the <a href="https://github.com/micro-editor/micro/tree/master/runtime/help/tutorial.md">tutorial</a> for
                         a brief introduction to the more powerful configuration features micro offers.</p>
 
                     <br>
-                    <p>If you have any questions, feel free to open an issue in the <a href="https://github.com/zyedidia/micro/issues">GitHub issue tracker</a> or to ask more informally in the <a href="https://gitter.im/zyedidia/micro">Gitter chat</a></p>
+                    <p>If you have any questions, feel free to open an issue in the <a href="https://github.com/micro-editor/micro/issues">GitHub issue tracker</a> or to ask more informally in the <a href="https://gitter.im/zyedidia/micro">Gitter chat</a></p>
                 </div>
                 <div class="col-sm-1">
                 </div>
                 <div class="col-sm-3">
                     <h4>Help topics</h4>
                     <ul style="list-style-type:none; padding:0;">
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/help.md">main help</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/keybindings.md">keybindings</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/commands.md">commands</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/colors.md">colors</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/options.md">options</a></li>
-                        <li><a href="https://github.com/zyedidia/micro/tree/master/runtime/help/plugins.md">plugins</a></li>
+                        <li><a href="https://github.com/micro-editor/micro/tree/master/runtime/help/help.md">main help</a></li>
+                        <li><a href="https://github.com/micro-editor/micro/tree/master/runtime/help/keybindings.md">keybindings</a></li>
+                        <li><a href="https://github.com/micro-editor/micro/tree/master/runtime/help/commands.md">commands</a></li>
+                        <li><a href="https://github.com/micro-editor/micro/tree/master/runtime/help/colors.md">colors</a></li>
+                        <li><a href="https://github.com/micro-editor/micro/tree/master/runtime/help/options.md">options</a></li>
+                        <li><a href="https://github.com/micro-editor/micro/tree/master/runtime/help/plugins.md">plugins</a></li>
                     </ul>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                         <li class="active"><a href="index.html">home</a></li>
                         <li><a href="about.html">about</a></li>
                         <li><a href="plugins.html">plugins</a></li>
-                        <li><a href="https://github.com/zyedidia/micro">development</a></li>
+                        <li><a href="https://github.com/micro-editor/micro">development</a></li>
                     </ul>
                 </div>
             </div>
@@ -59,10 +59,10 @@
             <div class="jumbotron">
                 <p style="font-weight:bold;" class="lead heading">micro</p>
                 <p class="lead">a modern and intuitive terminal-based text editor</p>
-                <p><a class="btn btn-lg btn-success" href="https://github.com/zyedidia/micro/releases/latest" role="button">Download</a></p>
+                <p><a class="btn btn-lg btn-success" href="https://github.com/micro-editor/micro/releases/latest" role="button">Download</a></p>
                 <pre style="max-width:20em;clear:both;text-align:center;margin:0 auto"><code id="selectable" onclick="selectText(this)">curl https://getmic.ro | bash</code></pre><br>
-                <a class="github-button" href="https://github.com/zyedidia/micro" data-size="large" data-show-count="true" aria-label="Star zyedidia/micro on GitHub">Star</a>
-                <p><a style='font-size: 16px;' href="https://github.com/zyedidia/micro#installation">See detailed installation instructions</a></p>
+                <a class="github-button" href="https://github.com/micro-editor/micro" data-size="large" data-show-count="true" aria-label="Star micro-editor/micro on GitHub">Star</a>
+                <p><a style='font-size: 16px;' href="https://github.com/micro-editor/micro#installation">See detailed installation instructions</a></p>
             </div>
             <hr>
 
@@ -178,7 +178,7 @@
 
                 <div class="col-lg-12">
                     <br>
-                    <p style="padding-top: 20px;">And much more! Check out the full list of features <a href="https://github.com/zyedidia/micro#features">here</a> as well as the built-in help system also viewable online <a href="https://github.com/zyedidia/micro/tree/master/runtime/help">here</a>.</p>
+                    <p style="padding-top: 20px;">And much more! Check out the full list of features <a href="https://github.com/micro-editor/micro#features">here</a> as well as the built-in help system also viewable online <a href="https://github.com/micro-editor/micro/tree/master/runtime/help">here</a>.</p>
                 </div>
             </div>
 
@@ -194,7 +194,7 @@
                     <p>For a more informal setting to discuss the editor, you can join the Gitter chat.</p>
                     <br>
                     <div class="col-sm-6">
-                        <p style="text-align:center"><a class="btn btn-md btn-success" href="https://github.com/zyedidia/micro" role="button">View the GitHub project</a></p>
+                        <p style="text-align:center"><a class="btn btn-md btn-success" href="https://github.com/micro-editor/micro" role="button">View the GitHub project</a></p>
                     </div>
                     <div class="col-sm-6">
                         <p style="text-align:center"><a class="btn btn-md btn-success" href="https://gitter.im/zyedidia/micro" role="button">Join the Gitter Chat</a></p>
@@ -207,7 +207,7 @@
                     <ul class="testimonials">
                         <li><p><a href="https://gitter.im/zyedidia/micro?at=57c5b2069bac566763729ac2">"Finally a simple editor that just works, with amazing mouse support."</a></p></li>
                         <li><p><a href="https://www.reddit.com/r/golang/comments/4f8e0q/micro_a_modern_and_intuitive_terminalbased_text/d26qse8">"I really love this. This is definitely replacing nano for me."</a></p></li>
-                        <li><p><a href="https://github.com/zyedidia/micro/issues/217#issuecomment-243134046">"Keep up the great work, you have saved me from Nano and Vim suffering!"</a></p></li>
+                        <li><p><a href="https://github.com/micro-editor/micro/issues/217#issuecomment-243134046">"Keep up the great work, you have saved me from Nano and Vim suffering!"</a></p></li>
                         <li><p><a href="https://twitter.com/kelseyhightower/status/770735086400577536">"The micro text editor is dope."</a></p></li>
                         <li><p><a href="https://www.reddit.com/r/commandline/comments/5059qw/micro_a_modern_and_intuitive_terminalbased_text/d71t2y8">"Nice, readable source, with generous use of comments. I wonder if this is that 'idiomatic go' I keep hearing about."</a></p></li>
                     </ul>

--- a/plugins.html
+++ b/plugins.html
@@ -45,7 +45,7 @@
                         <li><a href="index.html">home</a></li>
                         <li><a href="about.html">about</a></li>
                         <li class="active"><a href="plugins.html">plugins</a></li>
-                        <li><a href="https://github.com/zyedidia/micro">development</a></li>
+                        <li><a href="https://github.com/micro-editor/micro">development</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
To fit to the new location within the [micro-editor](https://github.com/micro-editor) organization.
Just kept the https://gitter.im/zyedidia/micro URL.